### PR TITLE
F/internalize profiles

### DIFF
--- a/lib/spec/builder/spec_builder_13X/spec_configuration_dsl_13X.rb
+++ b/lib/spec/builder/spec_builder_13X/spec_configuration_dsl_13X.rb
@@ -21,6 +21,7 @@ module StructCore
 			type = type.to_s
 			return if type.empty?
 
+			@configuration.profiles << "general:#{type}"
 			@configuration.raw_type = type
 		end
 

--- a/lib/spec/builder/spec_builder_13X/spec_configuration_dsl_13X.rb
+++ b/lib/spec/builder/spec_builder_13X/spec_configuration_dsl_13X.rb
@@ -6,11 +6,6 @@ module StructCore
 
 		attr_accessor :configuration
 
-		def profile(profile = nil)
-			return unless profile.is_a?(String) && !profile.empty?
-			@configuration.profiles << profile
-		end
-
 		def override(key = nil, value = nil)
 			return unless key.is_a?(String) && !key.empty? && value.is_a?(String)
 			@configuration.overrides[key] = value

--- a/lib/spec/builder/spec_builder_13X/spec_configuration_dsl_13X.rb
+++ b/lib/spec/builder/spec_builder_13X/spec_configuration_dsl_13X.rb
@@ -22,7 +22,7 @@ module StructCore
 			return if type.empty?
 
 			@configuration.profiles << "general:#{type}"
-			@configuration.raw_type = type
+			@configuration.type = type
 		end
 
 		def source(source = nil)

--- a/lib/spec/builder/spec_builder_13X/spec_target_configuration_dsl_13X.rb
+++ b/lib/spec/builder/spec_builder_13X/spec_target_configuration_dsl_13X.rb
@@ -6,11 +6,6 @@ module StructCore
 
 		attr_accessor :configuration
 
-		def profile(profile = nil)
-			return unless profile.is_a?(String) && !profile.empty?
-			@configuration.profiles << profile
-		end
-
 		def override(key = nil, value = nil)
 			return unless key.is_a?(String) && !key.empty? && value.is_a?(String)
 			@configuration.settings[key] = value

--- a/lib/spec/parser/spec_parser_1_3_X.rb
+++ b/lib/spec/parser/spec_parser_1_3_X.rb
@@ -33,7 +33,7 @@ module StructCore
 				end
 
 				valid_configuration_names << name
-				config = Specfile::Configuration.new(name, config['profiles'], config['overrides'] || {}, config['type'])
+				config = Specfile::Configuration.new(name, config['overrides'] || {}, config['type'])
 				
 				if config.type.nil?
 					puts Paint["Warning: Configuration with name '#{name}' was skipped as its type did not match one of: debug, release"]
@@ -109,14 +109,8 @@ module StructCore
 
 		def parse_variant_target_profiles(target_opts, raw_type, target_name)
 			# Parse target platform/type/profiles into a profiles list
-			profiles = []
-			
-			if target_opts.key?('platform')
-				raw_platform = target_opts['platform']
-				profiles = [raw_type, "platform:#{raw_platform}"].compact
-			end
-
-			profiles
+			platform = target_opts['platform']
+			[raw_type, "platform:#{platform}"].compact
 		end
 
 		def parse_variant_target_configurations(target_opts, valid_config_names, profiles)

--- a/lib/spec/parser/spec_parser_1_3_X.rb
+++ b/lib/spec/parser/spec_parser_1_3_X.rb
@@ -26,6 +26,7 @@ module StructCore
 		def parse_configurations(spec_hash)
 			valid_configuration_names = []
 			configurations = spec_hash['configurations'].map { |name, config|
+			
 				unless config['source'].nil?
 					valid_configuration_names << name
 					next Specfile::Configuration.new(name, [], {}, config['type'], config['source'])

--- a/lib/spec/parser/spec_parser_1_3_X.rb
+++ b/lib/spec/parser/spec_parser_1_3_X.rb
@@ -39,7 +39,7 @@ module StructCore
 
 				valid_configuration_names << name
 				config = Specfile::Configuration.new(name, config['profiles'], config['overrides'] || {}, config['type'])
-
+				
 				if config.type.nil?
 					puts Paint["Warning: Configuration with name '#{name}' was skipped as its type did not match one of: debug, release"]
 					next nil

--- a/lib/spec/parser/spec_parser_1_3_X.rb
+++ b/lib/spec/parser/spec_parser_1_3_X.rb
@@ -32,11 +32,6 @@ module StructCore
 					next Specfile::Configuration.new(name, [], {}, config['type'], config['source'])
 				end
 
-				unless config.key?('profiles') && config['profiles'].is_a?(Array) && config['profiles'].count > 0
-					puts Paint["Warning: Configuration with name '#{name}' was skipped as it was invalid"]
-					next nil
-				end
-
 				valid_configuration_names << name
 				config = Specfile::Configuration.new(name, config['profiles'], config['overrides'] || {}, config['type'])
 				
@@ -115,13 +110,8 @@ module StructCore
 		def parse_variant_target_profiles(target_opts, raw_type, target_name)
 			# Parse target platform/type/profiles into a profiles list
 			profiles = []
-			if target_opts.key? 'profiles'
-				if target_opts['profiles'].is_a?(Array)
-					profiles = target_opts['profiles']
-				else
-					puts Paint["Warning: Key 'profiles' for variant override #{target_name} is not an array. Ignoring...", :yellow]
-				end
-			elsif profiles.nil? && target_opts.key?('platform')
+			
+			if target_opts.key?('platform')
 				raw_platform = target_opts['platform']
 				profiles = [raw_type, "platform:#{raw_platform}"].compact
 			end

--- a/lib/spec/spec_file.rb
+++ b/lib/spec/spec_file.rb
@@ -23,10 +23,10 @@ module StructCore
 
 		class Target
 			class Configuration
-				def initialize(name, settings, source = nil)
+				def initialize(name, settings, profiles = nil, source = nil)
 					@name = name
 					@settings = settings
-					@profiles = []
+					@profiles = profiles || []
 					@source = source
 				end
 
@@ -121,29 +121,20 @@ module StructCore
 			def initialize(target_name, target_type, source_dir, configurations, references, options, res_dir, file_excludes, postbuild_run_scripts = [], prebuild_run_scripts = [])
 				@name = target_name
 				@type = target_type
-				
-				@profiles = [
-					target_type
-				]
-
 				@source_dir = []
-				
 				unless source_dir.nil?
 					@source_dir = [source_dir]
 					@source_dir = [].unshift(*source_dir) if source_dir.is_a? Array
 				end
-
 				@configurations = configurations
 				@references = references
 				@options = options
-
 				if !res_dir.nil?
 					@res_dir = [res_dir]
 					@res_dir = [].unshift(*res_dir) if res_dir.is_a? Array
 				else
 					@res_dir = @source_dir
 				end
-
 				@file_excludes = file_excludes || []
 				@postbuild_run_scripts = postbuild_run_scripts || []
 				@prebuild_run_scripts = prebuild_run_scripts || []

--- a/lib/spec/spec_file.rb
+++ b/lib/spec/spec_file.rb
@@ -121,6 +121,11 @@ module StructCore
 			def initialize(target_name, target_type, source_dir, configurations, references, options, res_dir, file_excludes, postbuild_run_scripts = [], prebuild_run_scripts = [])
 				@name = target_name
 				@type = target_type
+				
+				@profiles = [
+					target_type
+				]
+
 				@source_dir = []
 				
 				unless source_dir.nil?

--- a/lib/spec/spec_file.rb
+++ b/lib/spec/spec_file.rb
@@ -16,9 +16,9 @@ module StructCore
 
 			# @return [String]
 			def type
-				if @name == 'debug'
+				if @name.downcase == 'debug'
 					'debug'
-				elsif @name == 'release'
+				elsif @name.downcase == 'release'
 					'release'
 				else
 					@raw_type

--- a/lib/spec/spec_file.rb
+++ b/lib/spec/spec_file.rb
@@ -6,9 +6,9 @@ require_relative 'writer/spec_writer'
 module StructCore
 	class Specfile
 		class Configuration
-			def initialize(name, profiles, overrides, type = nil, source = nil)
+			def initialize(name, overrides, type = nil, source = nil)
 				@name = name
-				@profiles = profiles || ["general:#{type}"]
+				@profiles = ["general:#{type}"]
 				@overrides = overrides
 				@type = type || @name.downcase 
 				@source = source
@@ -23,10 +23,10 @@ module StructCore
 
 		class Target
 			class Configuration
-				def initialize(name, settings, profiles = nil, source = nil)
+				def initialize(name, settings, source = nil)
 					@name = name
 					@settings = settings
-					@profiles = profiles || []
+					@profiles = []
 					@source = source
 				end
 
@@ -122,19 +122,23 @@ module StructCore
 				@name = target_name
 				@type = target_type
 				@source_dir = []
+				
 				unless source_dir.nil?
 					@source_dir = [source_dir]
 					@source_dir = [].unshift(*source_dir) if source_dir.is_a? Array
 				end
+
 				@configurations = configurations
 				@references = references
 				@options = options
+
 				if !res_dir.nil?
 					@res_dir = [res_dir]
 					@res_dir = [].unshift(*res_dir) if res_dir.is_a? Array
 				else
 					@res_dir = @source_dir
 				end
+
 				@file_excludes = file_excludes || []
 				@postbuild_run_scripts = postbuild_run_scripts || []
 				@prebuild_run_scripts = prebuild_run_scripts || []

--- a/lib/spec/spec_file.rb
+++ b/lib/spec/spec_file.rb
@@ -8,28 +8,16 @@ module StructCore
 		class Configuration
 			def initialize(name, profiles, overrides, type = nil, source = nil)
 				@name = name
-				@profiles = profiles
+				@profiles = profiles || ["general:#{type}"]
 				@overrides = overrides
-				@raw_type = type
+				@type = type || @name.downcase 
 				@source = source
-			end
-
-			# @return [String]
-			def type
-				if @name.downcase == 'debug'
-					'debug'
-				elsif @name.downcase == 'release'
-					'release'
-				else
-					@raw_type
-				end
 			end
 
 			attr_writer :type
 			attr_accessor :name
 			attr_accessor :profiles
 			attr_accessor :overrides
-			attr_accessor :raw_type
 			attr_accessor :source
 		end
 


### PR DESCRIPTION
My initial attempt at internalizing them. I've removed Profiles from the parse + DSL where I can and will infer them.

The internal API still uses it but it would be great to move inferring as far down the stack as possible since it would simplify things for Cook.

I will go into more details in the Architecture Wiki Page but if we tweaked the parser to just convert the YML/JSON to the DSL would simplify things since I had to duplicate logic across the Parser and DSL.